### PR TITLE
README refinements

### DIFF
--- a/workshop/README.md
+++ b/workshop/README.md
@@ -32,6 +32,7 @@ This repository is Codespaces-ready and is pre-configured so that you have all d
 > If using this repository in your account or a non-GitHub-Universe organization, you might incur in charges or consumption of your free quoota for Codespaces.
 
 ### 1. Create a new repository from this template
+
 Progress: [🟢⚪⚪⚪⚪⚪⚪⚪⚪⚪⚪⚪] 1/12 (8%)
 
 ⏳ **~2min**
@@ -43,6 +44,7 @@ Progress: [🟢⚪⚪⚪⚪⚪⚪⚪⚪⚪⚪⚪] 1/12 (8%)
 - Click `Create repository`
 
 ### 2. Create a Codespace using the provided template
+
 Progress: [🟢🟢⚪⚪⚪⚪⚪⚪⚪⚪⚪⚪] 2/12 (16%)
 
 ⏳ **~3min**
@@ -59,6 +61,7 @@ Progress: [🟢🟢⚪⚪⚪⚪⚪⚪⚪⚪⚪⚪] 2/12 (16%)
     > There is no need to push changes back to the repo during the workshop
 
 ### 3. Verify Python is installed and set correctly
+
 Progress: [🟢🟢🟢⚪⚪⚪⚪⚪⚪⚪⚪⚪] 3/12 (25%)
 
 ⏳ **~2min**
@@ -68,10 +71,10 @@ Progress: [🟢🟢🟢⚪⚪⚪⚪⚪⚪⚪⚪⚪] 3/12 (25%)
 - Run `which pip` and ensure that it also points to the Virtual Environment (`home/vscode/venv/bin/pip`)
 
 ### 4. Run the Python scripts
+
 Progress: [🟢🟢🟢🟢⚪⚪⚪⚪⚪⚪⚪⚪] 4/12 (33%)
 
 ⏳ **~2min**
-
 
 - Run the `main.py` script and confirm no errors occur:
 
@@ -96,6 +99,7 @@ Progress: [🟢🟢🟢🟢⚪⚪⚪⚪⚪⚪⚪⚪] 4/12 (33%)
     ```
 
 ### 5. Open relevant files
+
 Progress: [🟢🟢🟢🟢🟢⚪⚪⚪⚪⚪⚪⚪] 5/12 (41%)
 
 ⏳ **~2min**
@@ -107,6 +111,7 @@ GitHub Copilot benefits from having context. One way to enhance context is by op
 ## Development
 
 ### 1. See how much you can learn about the project and the data
+
 Progress: [🟢🟢🟢🟢🟢🟢⚪⚪⚪⚪⚪⚪] 6/12 (50%) - Half way through!
 
 ⏳ **~5min**
@@ -116,6 +121,7 @@ Progress: [🟢🟢🟢🟢🟢🟢⚪⚪⚪⚪⚪⚪] 6/12 (50%) - Half way thr
 - Again, with the `@workspace` agent, ask Copilot what is the nature of the data you are going to work with
 
 #### 2. Fix the high ratings function
+
 Progress: [🟢🟢🟢🟢🟢🟢🟢⚪⚪⚪⚪⚪] 7/12 (58%)
 
 ⏳ **~3min**
@@ -152,8 +158,8 @@ Based on the provided code, there are a few potential reasons why the `select_hi
 > Feel free to use the GitHub Copilot Chat to implement or corroborate the fix
 
 #### 3. Fix the one-hot encoding problem
-Progress: [🟢🟢🟢🟢🟢🟢🟢🟢⚪⚪⚪⚪] 8/12 (66%)
 
+Progress: [🟢🟢🟢🟢🟢🟢🟢🟢⚪⚪⚪⚪] 8/12 (66%)
 
 ⏳ **~3min**
 
@@ -188,10 +194,12 @@ def drop_and_one_hot_encode_red_wine(df):
 </details>
 
 #### 4. Fix the ratings conversion to int
+
 Progress: [🟢🟢🟢🟢🟢🟢🟢🟢🟢⚪⚪⚪] 9/12 (75%)
 
 ⏳ **~3min**
 
+- If your `verify_ratings_to_int` check is already "OK", then Copilot may have already fixed this issue for you. If not, continue with the following steps.
 - Select the `convert_ratings_to_int()` function and open inline chat (Ctrl-i / Cmd-i)
 - Use the `/explain` slash command to ask GitHub Copilot why this function might not be working correctly
 - Identify the problem and implement the fix
@@ -208,7 +216,6 @@ This function is not converting the ratings to integers
 ```
 
 ##### Expected output
-
 
 ```python
 def convert_ratings_to_int(df):
@@ -229,8 +236,8 @@ A robust Python project can benefit from testing. You will add some unit tests a
 Make sure you have the terminal open by running the command palette and typing `toggle terminal`
 
 ### 1. Test your CLI
-Progress: [🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢⚪⚪] 10/12 (83%)
 
+Progress: [🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢⚪⚪] 10/12 (83%)
 
 ⏳ **~5min**
 
@@ -240,28 +247,49 @@ Progress: [🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢⚪⚪] 10/12 (83%)
 The output should give you a failure.
 
 #### 2. Fix the failing test
+
 Progress: [🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢⚪] 11/12 (91%)
 
 ⏳ **~5min**
 
-- Select the output in the terminal and paste it into GitHub Copilot Chat
+- Select the output in the terminal and paste it into GitHub Copilot Chat, prefixing with a request for a fix and an explanation
 - Use the output from the chat to implement a fix in `test_main.py`
 
 <details>
 <summary>Cheatsheet</summary>
 
+##### Prompt
+
+```sh
+Fix the test and explain your fix:
+// Copy and paste the output from the terminal here
+```
 
 ##### Expected output
 
-The error indicates that the drop_notes function did not drop the 'note' column as expected. This is likely due to a typo in the test case where the column name is 'note' instead of 'notes'.
+The error occurs because the drop_notes function is likely modifying the DataFrame in place, rather than returning a new DataFrame with the 'notes' column dropped. To fix the test, we need to ensure that the drop_notes function returns a new DataFrame without the 'notes' column and then check the columns of this new DataFrame.
 
-**Plan**
+Here is the corrected test function:
 
-Fix the test case: Ensure the column name in the test case matches the column name expected by the drop_notes function.
+```python
+def test_drop_notes_column_dropped():
+    # Create a sample DataFrame with 'notes' column
+    df = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6], 'notes': ['note1', 'note2', 'note3']})
+
+    # Call the drop_notes function and get the result
+    result = main.drop_notes(df)
+    
+    # Assert that 'notes' column in result dataframe is dropped
+    columns = result.columns.to_list()
+    assert columns == ['A', 'B']
+```
+
+By storing the result of the drop_notes function in a new variable and checking its columns, we ensure that the test correctly verifies the behavior of the function.
 
 </details>
 
 #### 3. Add tests for the one hot encoding function
+
 Progress: [🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢] 12/12 (100%) - 🎉 Celebrate!
 
 ⏳ **~5min**
@@ -270,7 +298,7 @@ Progress: [🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢] 12/12 (100%) - 🎉
 - Select the `drop_and_one_hot_encode_red_wine` function in `main.py`
 - Open inline chat with `Ctrl-i`/`Cmd-i`
 - Use the `/tests` slash command to get suggestions on tests
-- Review the output, accept it, and verify with the `pytest -v` command. All tests should be passing, and you should have more tests than before.
+- Review the output, accept it, and verify with the `pytest -v` command. All tests should be passing, and you should have more tests than before. Sometimes Copilot will indent the suggested tests incorrectly (nesting them inside an existing test function), so make sure the tests are correctly indented before running them.
 
 <details>
 <summary>Cheatsheet</summary>
@@ -328,13 +356,15 @@ def test_drop_and_one_hot_encode_red_wine_dataframe_unchanged():
     assert 'variety' in df.columns
     assert df.shape == (3, 3)
 ```
+
 </details>
 
-## Bonus!
+## Bonus
 
 There are a couple of bonus challenges if you've completed all the tasks and your scripts are in good shape.
 
 ### Bonus Challenge 1 - Create a robust CLI tool
+
 Progress: [🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢] 12/12 (100%) 🎉  
 Optional: [🚀 Turbo Boost! (1/2) 50%]  
 
@@ -344,13 +374,13 @@ Optional: [🚀 Turbo Boost! (1/2) 50%]
 <details>
 <summary>Cheatsheet</summary>
 
-##### Prompt
+#### Prompt
 
-```
+```shell
 @workspace I want to convert this project into a CLI with a help menu. Help me do this without using any dependencies, just pure Python standard library
 ```
 
-##### Expected output
+#### Expected output
 
 ```python
 def main():
@@ -387,9 +417,11 @@ def main():
 if __name__ == "__main__":
     main()
 ```
+
 </details>
 
 ### Bonus Challenge 2 - Document your project
+
 Progress: [🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢🟢] 12/12 (100%) 🎉  
 Optional: [🚀 Turbo Boost! (1/2) 50%]  
 Optional: [🌟 Extra Points! (2/2) 100% 🏆]
@@ -401,13 +433,13 @@ Optional: [🌟 Extra Points! (2/2) 100% 🏆]
 <details>
 <summary>Cheatsheet</summary>
 
-##### Prompt
+#### Prompt
 
-```
+```shell
 @workspace help me create a good README.md file in Markdown so that I can document this and help others understand how it works and the nature of the data
 ```
 
-##### Expected output
+#### Expected output
 
 ```markdown
 # DataFrame Manipulation CLI
@@ -506,6 +538,7 @@ Contributions are welcome! Please follow these steps to contribute:
 
 This project is licensed under the MIT License. See the [LICENSE](../LICENSE) file for details.
 ```
+
 </details>
 
 ## Clean-up

--- a/workshop/test_main.py
+++ b/workshop/test_main.py
@@ -5,13 +5,13 @@ import main
 
 def test_drop_notes_column_dropped():
     # Create a sample DataFrame with 'notes' column
-    df = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6], 'note': ['note1', 'note2', 'note3']})
+    df = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6], 'notes': ['note1', 'note2', 'note3']})
 
     # Call the drop_notes function
-    result = main.drop_notes(df)
+    main.drop_notes(df)
     
     # Assert that 'notes' column is dropped
-    columns = result.columns.to_list()
+    columns = df.columns.to_list()
     assert columns == ['A', 'B']
     
     


### PR DESCRIPTION
I went through the workshop again, here are some suggestions based on my experience. Some of the fixes are Markdown lint errors (new lines / heading levels). The most significant change was to the pytest step 1, as I could not get Copilot to fix that correctly, after 10 attempts. So I changed it to another classic error, forgetting to use a return value.